### PR TITLE
feat(version): adds version of packages as meta data

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "update-staging": "yarn upgrade @carbon/ibmdotcom-react@latest && yarn upgrade @carbon/ibmdotcom-styles@latest"
   },
   "dependencies": {
-    "@carbon/ibmdotcom-react": "^1.5.0-rc.1",
-    "@carbon/ibmdotcom-styles": "^1.5.0-rc.1",
+    "@carbon/ibmdotcom-react": "^1.6.0-alpha.3240",
+    "@carbon/ibmdotcom-styles": "^1.6.0-alpha.3201",
     "@carbon/icons-react": "^10.9.1",
     "@carbon/pictograms-react": "^10.9.0",
     "@zeit/next-css": "^1.0.1",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -6,6 +6,7 @@ import App from 'next/app';
 import {DotcomShell} from '@carbon/ibmdotcom-react';
 import Head from 'next/head';
 import React from 'react';
+import packageJson from '../package.json';
 
 /**
  * Language codes for the DotcomShell for server side render
@@ -61,6 +62,8 @@ export default class IbmdotcomLibrary extends App {
    */
   render() {
     const {Component, useLang, pageProps} = this.props;
+    const reactVersion = packageJson.dependencies["@carbon/ibmdotcom-react"];
+    const stylesVersion = packageJson.dependencies["@carbon/ibmdotcom-styles"];
     return (
       <>
         <Head>
@@ -71,6 +74,8 @@ export default class IbmdotcomLibrary extends App {
           <meta name="dcterms.rights" content="© Copyright IBM Corp. 2020"/>
           <meta name="geo.country" content="US"/>
           <meta name="robots" content="index,follow" />
+          <meta name="ibmdotcom.version.react" content={reactVersion} />
+          <meta name="ibmdotcom.version.styles" content={stylesVersion} />
         </Head>
         <DotcomShell navigation="default" langCode={useLang}>
           <Component {...pageProps} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -848,15 +848,15 @@
     "@carbon/import-once" "^10.3.0"
     "@carbon/layout" "^10.8.1"
 
-"@carbon/ibmdotcom-react@^1.5.0-rc.1":
-  version "1.5.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@carbon/ibmdotcom-react/-/ibmdotcom-react-1.5.0-rc.1.tgz#4388c1911c1f06bce5cef585047def359ed8cf38"
-  integrity sha512-cvXpOzwOjpZR6vOk8YfYH1wfPiW4awaj6t9X0cP5gWG86sIWE4J7W+nEZthRJxVwdLbJU9DbOKqfXlV43J3/ZA==
+"@carbon/ibmdotcom-react@^1.6.0-alpha.3240":
+  version "1.6.0-alpha.3240"
+  resolved "https://registry.yarnpkg.com/@carbon/ibmdotcom-react/-/ibmdotcom-react-1.6.0-alpha.3240.tgz#64a72d14b101dcac445fe1f60d93405510cb471f"
+  integrity sha512-TZdqTgLZ5mTj4Wb6dxlHbQBuJCh7V2eCRjLulxgjDRuec3PzTeESFnMA69JtdviFWHu72TgiCdjVT+ViAav9ig==
   dependencies:
     "@babel/runtime" "^7.5.5"
-    "@carbon/ibmdotcom-services" "1.5.0-rc.0"
-    "@carbon/ibmdotcom-styles" "1.5.0-rc.1"
-    "@carbon/ibmdotcom-utilities" "1.5.0-rc.0"
+    "@carbon/ibmdotcom-services" "1.5.1"
+    "@carbon/ibmdotcom-styles" "1.5.1"
+    "@carbon/ibmdotcom-utilities" "1.5.1"
     autosuggest-highlight "^3.1.1"
     carbon-components "10.9.0"
     carbon-components-react "7.9.0"
@@ -865,20 +865,20 @@
     react-autosuggest "^9.4.3"
     window-or-global "^1.0.1"
 
-"@carbon/ibmdotcom-services@1.5.0-rc.0":
-  version "1.5.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@carbon/ibmdotcom-services/-/ibmdotcom-services-1.5.0-rc.0.tgz#49c73d2a8c1aacf10dbbe121c414ed10b9be1972"
-  integrity sha512-L7bcrdJxreyQYpk+4yYyAiNJKNnX5X6svGtmm/pVE1Jl8pRdE3sqS8rvXvQFRsOlfcZ48vpFqL2B8n9ynIUt/A==
+"@carbon/ibmdotcom-services@1.5.1":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@carbon/ibmdotcom-services/-/ibmdotcom-services-1.5.1.tgz#3ef4bd05a277c4b893b4aaa91948751f23f1759a"
+  integrity sha512-dP7Hp98mCRDgRWzhK5RkPRz9mVaLzndZtlnPLNmbkbaoE6Ft3I/J+z9NMfzwz4X2g04sfXc0JagrdwZy2weSDA==
   dependencies:
-    "@carbon/ibmdotcom-utilities" "1.5.0-rc.0"
+    "@carbon/ibmdotcom-utilities" "1.5.1"
     axios "^0.19.0"
     jsonp "^0.2.1"
     window-or-global "^1.0.1"
 
-"@carbon/ibmdotcom-styles@1.5.0-rc.1", "@carbon/ibmdotcom-styles@^1.5.0-rc.1":
-  version "1.5.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@carbon/ibmdotcom-styles/-/ibmdotcom-styles-1.5.0-rc.1.tgz#935bf3aa5dca2b023efb30bf43a842222db9c19d"
-  integrity sha512-VCzE8IS5oGNv5DilkyCrcTlF+Cjb3f8krpFrP8Rz631/LEZ64V2XWiALu7FS1MNJolpQKQmsjp5iZDoU4wMDtw==
+"@carbon/ibmdotcom-styles@1.5.1":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@carbon/ibmdotcom-styles/-/ibmdotcom-styles-1.5.1.tgz#fd1e338a563ef31899d568e9cc96f0d537813b5a"
+  integrity sha512-1Nv2EDmx+/vdr+gGYxDR+XO9ffKIhrjTrWch42mYXnOfRBapKArRRp8OhXwrIhIeiHggjY/cDk8uCgjtp59LOA==
   dependencies:
     "@carbon/grid" "^10.8.3"
     "@carbon/import-once" "10.3.0"
@@ -888,10 +888,23 @@
     "@carbon/type" "10.8.3"
     carbon-components "10.9.0"
 
-"@carbon/ibmdotcom-utilities@1.5.0-rc.0":
-  version "1.5.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@carbon/ibmdotcom-utilities/-/ibmdotcom-utilities-1.5.0-rc.0.tgz#385b2551dc4fcad4cd18ed1f1d2f834059e17d8f"
-  integrity sha512-9WgDG30eTSZHNu513lEvKg5nmyhM0Pbmg993QfNZ3+gCImcEGmDYYpUZTUYfYZO3AU87qrowZh67RDu985gTcA==
+"@carbon/ibmdotcom-styles@^1.6.0-alpha.3201":
+  version "1.6.0-alpha.3201"
+  resolved "https://registry.yarnpkg.com/@carbon/ibmdotcom-styles/-/ibmdotcom-styles-1.6.0-alpha.3201.tgz#d79f8bfc6434f76b68fe2665d32be7ec2cc1db83"
+  integrity sha512-56yQjfhO/7giqKYV6aI21mxyxlfcCJqQOi35w/ej4LmtX1CSKjojZRP0oXBub8Rmv+K+ABnCJhdZLFgpTWXN+g==
+  dependencies:
+    "@carbon/grid" "^10.8.3"
+    "@carbon/import-once" "10.3.0"
+    "@carbon/layout" "10.7.3"
+    "@carbon/motion" "^10.5.2"
+    "@carbon/themes" "10.9.0"
+    "@carbon/type" "10.8.3"
+    carbon-components "10.10.1"
+
+"@carbon/ibmdotcom-utilities@1.5.1":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@carbon/ibmdotcom-utilities/-/ibmdotcom-utilities-1.5.1.tgz#86b655631a4473674da6aa88dd3f069ea8be9e54"
+  integrity sha512-Idul7Q2IFkPf3awEXbseudXZwnq6k3J+CHJR0RREODk+hD7i5gPHtPwIU6LEREiFGVMUNOZsKMynQgYeThKf8g==
   dependencies:
     axios "^0.19.0"
     carbon-components "^10.7.4"
@@ -1817,17 +1830,7 @@ carbon-components-react@7.9.0:
     warning "^3.0.0"
     window-or-global "^1.0.1"
 
-carbon-components@10.9.0:
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/carbon-components/-/carbon-components-10.9.0.tgz#b96f097582301b009232ebc54927327ee3608a84"
-  integrity sha512-r0fHHGV1nAGazL42ecsFSBHlrRlg/2d1XAvnlnRzOvZW8O+DFR4XxpAgf5ZWKFCiiysS5eDympZTqTflN/NewQ==
-  dependencies:
-    carbon-icons "^7.0.7"
-    flatpickr "4.6.1"
-    lodash.debounce "^4.0.8"
-    warning "^3.0.0"
-
-carbon-components@^10.7.4:
+carbon-components@10.10.1, carbon-components@^10.7.4:
   version "10.10.1"
   resolved "https://registry.yarnpkg.com/carbon-components/-/carbon-components-10.10.1.tgz#db8bb3703123db402238283ab315aa23d5ab69a4"
   integrity sha512-qbZsbdz6cUD/cgiS3ww71pUWC3WzWOJMrEsfwLh/XItdJAs5P+Ax9HouMLrlM1ia1e9fW8xdUsqeMveuYIxk9w==
@@ -1836,6 +1839,16 @@ carbon-components@^10.7.4:
     flatpickr "4.6.1"
     lodash.debounce "^4.0.8"
     scss-to-json "^2.0.0"
+    warning "^3.0.0"
+
+carbon-components@10.9.0:
+  version "10.9.0"
+  resolved "https://registry.yarnpkg.com/carbon-components/-/carbon-components-10.9.0.tgz#b96f097582301b009232ebc54927327ee3608a84"
+  integrity sha512-r0fHHGV1nAGazL42ecsFSBHlrRlg/2d1XAvnlnRzOvZW8O+DFR4XxpAgf5ZWKFCiiysS5eDympZTqTflN/NewQ==
+  dependencies:
+    carbon-icons "^7.0.7"
+    flatpickr "4.6.1"
+    lodash.debounce "^4.0.8"
     warning "^3.0.0"
 
 carbon-icons@7.0.7, carbon-icons@^7.0.7:


### PR DESCRIPTION
### Related Ticket(s)

No related issues

### Description

This adds meta data that describes what version of the IBM.com Library react and styles packages that are being used.

![Screen Shot 2020-03-31 at 4 02 50 PM](https://user-images.githubusercontent.com/1641214/78071420-7895ce80-736b-11ea-985e-f09f17f929ce.png)

### Changelog

**New**

- meta tags with package versions on the app wrapper