### PR TITLE
fix(styles): switched from global style package to discrete imports

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,5 +1,4 @@
-import 'carbon-components/css/carbon-components.min.css';
-import '@carbon/ibmdotcom-styles/scss/ibm-dotcom-styles.scss';
+import '../styles/global.scss';
 
 import Altlang from '../components/altlang';
 import App from 'next/app';

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,4 +1,5 @@
 import { CardSectionSimple } from '@carbon/ibmdotcom-react';
+import '../styles/landing.scss';
 import React from 'react';
 
 /**

--- a/pages/learn.js
+++ b/pages/learn.js
@@ -13,6 +13,7 @@ import {
   CardSectionSimple,
 } from '@carbon/ibmdotcom-react';
 import { ArrowRight20 } from '@carbon/icons-react';
+import '../styles/learn.scss';
 import React from 'react';
 
 /**
@@ -40,7 +41,7 @@ const Learn = () => (
             breakpoint: 'md',
           },
         ],
-        defaultSrc: 'https://dummyimage.com/1056x480/ee5396/161616',
+        default: 'https://dummyimage.com/1056x480/ee5396/161616',
         alt: 'Image alt text',
       }}
     />

--- a/styles/global.scss
+++ b/styles/global.scss
@@ -1,0 +1,9 @@
+@import '@carbon/type/scss/font-face/mono';
+@import '@carbon/type/scss/font-face/sans';
+@include carbon--font-face-mono();
+@include carbon--font-face-sans();
+
+@import '@carbon/ibmdotcom-styles/scss/components/dotcom-shell/dotcom-shell';
+
+// Temporary missing imports for dotcom shell
+@import '@carbon/ibmdotcom-styles/scss/components/locale-modal/locale-modal';

--- a/styles/landing.scss
+++ b/styles/landing.scss
@@ -1,0 +1,4 @@
+@import '@carbon/ibmdotcom-styles/scss/patterns/sections/card-section/card-section';
+
+// Temporary missing imports from card section
+@import '@carbon/ibmdotcom-styles/scss/patterns/sub-patterns/card/index';

--- a/styles/learn.scss
+++ b/styles/learn.scss
@@ -1,0 +1,9 @@
+@import '@carbon/ibmdotcom-styles/scss/patterns/blocks/content-block-media/index';
+@import '@carbon/ibmdotcom-styles/scss/patterns/blocks/content-block-mixed/index';
+@import '@carbon/ibmdotcom-styles/scss/patterns/blocks/content-block-segmented/index';
+@import '@carbon/ibmdotcom-styles/scss/patterns/blocks/content-block-simple/index';
+@import '@carbon/ibmdotcom-styles/scss/patterns/sections/card-section/card-section';
+@import '@carbon/ibmdotcom-styles/scss/patterns/sub-patterns/tableofcontents/index';
+@import '@carbon/ibmdotcom-styles/scss/patterns/sub-patterns/link-list/index';
+@import '@carbon/ibmdotcom-styles/scss/patterns/sub-patterns/layout/layout';
+@import '@carbon/ibmdotcom-styles/scss/patterns/sections/leadspace/leadspace';


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

This switches out the NextJS application to use the discrete style imports for corresponding components/patterns.

### Changelog

**Changed**

- Style imports for IBM.com Library

**Removed**

- Importing all of carbon styles
