### PR TITLE
fix(leadspace-image-mobile-1617): new property name

### DIFF
--- a/pages/learn.js
+++ b/pages/learn.js
@@ -41,7 +41,7 @@ const Learn = () => (
             breakpoint: 'md',
           },
         ],
-        default: 'https://dummyimage.com/1056x480/ee5396/161616',
+        defaultSrc: 'https://dummyimage.com/1056x480/ee5396/161616',
         alt: 'Image alt text',
       }}
     />


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/ibm-dotcom-library/issues/1617

### Description

changed image data property from default to defaultSrc

### Changelog

**New**

- {{new thing}}

**Changed**

```
    <LeadSpace
...
        ],
        defaultSrc: 'https://dummyimage.com/1056x480/ee5396/161616',
        alt: 'Image alt text',
      }}
    />
```


