### PR TITLE
fix(learn): reduce card section bottom padding

### DIFF
--- a/styles/learn.scss
+++ b/styles/learn.scss
@@ -7,3 +7,7 @@
 @import "@carbon/ibmdotcom-styles/scss/patterns/sub-patterns/link-list/index";
 @import "@carbon/ibmdotcom-styles/scss/patterns/sub-patterns/layout/layout";
 @import "@carbon/ibmdotcom-styles/scss/patterns/sections/leadspace/leadspace";
+
+.bx--content-section:not(:last-child) {
+  padding-bottom: 48px;
+}


### PR DESCRIPTION
### Related Ticket(s)

Learn Page Template - The spacing between feature card , card with images and cards is too large. [#1654](https://app.zenhub.com/workspaces/ibmcom-library-5d449f3642eb1962336cbe52/issues/carbon-design-system/ibm-dotcom-library/1654)

### Description

spacing between card sections is too large, since the components don't have awareness of what other components are on the page, we are going to set the spacing via application level instead

### Changelog

**New**

- add styling to set spacing between card sections
