### PR TITLE
fix(page): prop updates to linklist and card for learn page

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -75,7 +75,14 @@ export default class IbmdotcomLibrary extends App {
           />
           <Altlang />
         </Head>
-        <DotcomShell navigation="default" langCode={useLang}>
+        <DotcomShell
+          mastheadProps={{
+            navigation: "default",
+          }}
+          footerProps={{
+            langCode: useLang,
+          }}
+        >
           <Component {...pageProps} />
         </DotcomShell>
         <script src="//1.www.s81c.com/common/stats/ibm-common.js"></script>

--- a/pages/learn.js
+++ b/pages/learn.js
@@ -195,6 +195,7 @@ const Learn = () => (
         aside={{
           items: (
             <LinkList
+              style="card"
               heading="Tutorials"
               items={[
                 {
@@ -349,7 +350,6 @@ const Learn = () => (
               },
               style: "card",
               type: "external",
-              heading: "Lorem ipsum dolor sit amet",
               copy: "Lorem ipsum dolor sit ametttt",
             }}
           />


### PR DESCRIPTION
### Related Ticket(s)

{{Provide url(s) to the related ticket(s) that this pull request addresses}}

### Description

Add `style` prop to the LinkList component to get the card styles. Also remove unnecessary `heading` prop from the `ContentBlockSimple` cta prop

### Changelog

**Changed**

- remove `heading` prop from `cta`
- add `styles` prop to LinkList
