### PR TITLE
fix(solutions): title fixes for the solution page

### DIFF
--- a/components/altlang.js
+++ b/components/altlang.js
@@ -1,5 +1,5 @@
-import altlangs from './data/altlang.json';
-import React from 'react';
+import altlangs from "./data/altlang.json";
+import React from "react";
 
 /**
  * Sets the root path of the alternative urls
@@ -7,7 +7,7 @@ import React from 'react';
  * @type {string|string}
  * @private
  */
-const _rootPath = process.env.ROOT_PATH || '/';
+const _rootPath = process.env.ROOT_PATH || "/";
 
 /**
  * Renders the list of altlang items
@@ -17,9 +17,10 @@ const _rootPath = process.env.ROOT_PATH || '/';
  */
 const _renderAltLangs = () => {
   let langs = [];
-  altlangs.forEach(alt => {
+  altlangs.forEach((alt, i) => {
     langs.push(
       <link
+        key={i}
         rel="alternate"
         hrefLang={`${alt.lc}-${alt.cc}`}
         href={`${_rootPath}?cc=${alt.cc}&lc=${alt.lc}`}

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "update-staging": "yarn upgrade @carbon/ibmdotcom-react@latest && yarn upgrade @carbon/ibmdotcom-styles@latest"
   },
   "dependencies": {
-    "@carbon/ibmdotcom-react": "latest",
-    "@carbon/ibmdotcom-styles": "latest",
+    "@carbon/ibmdotcom-react": "^1.8.0-rc.4",
+    "@carbon/ibmdotcom-styles": "^1.8.0-rc.3",
     "@carbon/icons-react": "^10.9.1",
     "@carbon/pictograms-react": "^10.9.0",
     "@commitlint/cli": "^8.3.5",

--- a/pages/solutions.js
+++ b/pages/solutions.js
@@ -26,11 +26,11 @@ import React from "react";
 const dds = () => (
   <>
     <TableOfContents menuLabel="Jump to" theme="white">
-      <a name="section-1" data-title="Lorem ipsum dolor sit amet" />
+      <a name="section-1" data-title="Lead Space Block" />
       <Layout type="2-1">
         <div>
           <LeadSpaceBlock
-            title="Lorem ipsum dolor sit amet"
+            title="Lead Space Block"
             copy="Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
             heading="Consectetur adipiscing elit, sed do eiusmod tempor incididunt ut."
             mediaType="video"
@@ -80,12 +80,9 @@ const dds = () => (
         <></>
       </Layout>
 
-      <a
-        name="section-2"
-        data-title="Pharetra pharetra massa massa ultricies mi quis."
-      />
+      <a name="section-2" data-title="Content Block Segmented" />
       <ContentBlockSegmented
-        heading="Pharetra pharetra massa massa ultricies mi quis."
+        heading="Content Block Segmented"
         items={[
           {
             heading: "A scelerisque purus semper eget duis at tellus.",
@@ -121,7 +118,7 @@ const dds = () => (
       />
       <FeatureCardBlockLarge
         eyebrow="scelerisque purus"
-        heading="Elementum nibh tellus molestie nunc?"
+        heading="Feature Card Block Large"
         copy="Habitant morbi tristique senectus et netus et malesuada fames. Habitant morbi tristique."
         cta={{
           href: "https://example.com",
@@ -135,12 +132,9 @@ const dds = () => (
         }}
       />
 
-      <a
-        name="section-3"
-        data-title="Elementum nibh tellus molestie nunc non"
-      />
+      <a name="section-3" data-title="Content Block Segmented (2)" />
       <ContentBlockSegmented
-        heading="Elementum nibh tellus molestie nunc non."
+        heading="Content Block Segmented (2)"
         items={[
           {
             heading: "A scelerisque purus semper eget duis at tellus.",
@@ -221,7 +215,7 @@ const dds = () => (
       />
 
       <CalloutWithMedia
-        heading="Mauris ultrices eros in cursus"
+        heading="Callout With Media"
         copy="Porttitor eget dolor morbi non arcu. Et ligula ullamcorper malesuada proin libero nunc consequat. In est ante in nibh mauris cursus mattis. Turpis tincidunt id aliquet risus feugiat in. Vel facilisis volutpat est velit egestas dui."
         mediaType="video"
         mediaData={{
@@ -230,9 +224,9 @@ const dds = () => (
         }}
       />
 
-      <a name="section-4" data-title="Tincidunt ornare massa" />
+      <a name="section-4" data-title="Content Group Horizontal" />
       <ContentGroupHorizontal
-        heading="Tincidunt ornare massa"
+        heading="Content Group Horizontal"
         items={[
           {
             eyebrow: "Lorem ipsum",
@@ -277,9 +271,9 @@ const dds = () => (
         ]}
       />
 
-      <a name="section-5" data-title="Lobortis elementum nibh tellus" />
+      <a name="section-5" data-title="Logo Grid" />
       <LogoGrid
-        heading="Lobortis elementum nibh tellus"
+        heading="Logo Grid"
         logosGroup={[
           {
             title: "Company A",
@@ -322,9 +316,9 @@ const dds = () => (
         ctaHref="https://www.example.com"
       />
 
-      <a name="section-6" data-title="Aliquam condimentum interdum" />
+      <a name="section-6" data-title="Content Block Cards" />
       <ContentBlockCards
-        heading="Aliquam condimentum interdum"
+        heading="Content Block Cards"
         cards={[
           {
             image: {
@@ -364,10 +358,10 @@ const dds = () => (
           },
         ]}
       />
-      <a name="section-7" data-title="Duis aute irure dolor in reprehenderit" />
+      <a name="section-7" data-title="Callout Quote" />
       <CalloutQuote
         quote={{
-          copy: "Duis aute irure dolor in reprehenderit",
+          copy: "Callout Quote: Duis aute irure dolor in reprehenderit",
           source: {
             heading: "Lorem ipsum",
             copy: "dolor sit amet",
@@ -416,7 +410,7 @@ const dds = () => (
           },
         },
       ]}
-      heading="Take the next step"
+      heading="CTA Section"
       copy="Want to discuss your options with a DevOps expert? Contact our sales team to evaluate your needs."
     />
   </>

--- a/styles/learn.scss
+++ b/styles/learn.scss
@@ -4,9 +4,9 @@
 @import "~@carbon/ibmdotcom-styles/scss/patterns/blocks/content-block-simple/index";
 @import "~@carbon/ibmdotcom-styles/scss/patterns/sections/card-section-images/card-section-images";
 @import "~@carbon/ibmdotcom-styles/scss/patterns/sections/card-section-simple/card-section-simple";
-@import "~@carbon/ibmdotcom-styles/scss/patterns/sub-patterns/tableofcontents/index";
-@import "~@carbon/ibmdotcom-styles/scss/patterns/sub-patterns/link-list/index";
-@import "~@carbon/ibmdotcom-styles/scss/patterns/sub-patterns/layout/layout";
+@import "~@carbon/ibmdotcom-styles/scss/components/tableofcontents/index";
+@import "~@carbon/ibmdotcom-styles/scss/components/link-list/index";
+@import "~@carbon/ibmdotcom-styles/scss/components/layout/layout";
 @import "~@carbon/ibmdotcom-styles/scss/patterns/sections/leadspace/leadspace";
 
 .bx--content-section:not(:last-child) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -977,14 +977,14 @@
     "@carbon/import-once" "^10.3.0"
     "@carbon/layout" "^10.9.2"
 
-"@carbon/ibmdotcom-react@latest":
-  version "1.8.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@carbon/ibmdotcom-react/-/ibmdotcom-react-1.8.0-rc.3.tgz#76c052e5cb2bcf1a0ca3b50863f4aedf3ae31f56"
-  integrity sha512-YhRjLOGggGttlIvTIqT/tz2ubpdFy53unUFGDqoSBeGxzBdh8ssZ4+kJ1uoCw1Glo23RaAkEyGhNnSmFbfPrBg==
+"@carbon/ibmdotcom-react@^1.8.0-rc.4":
+  version "1.8.0-rc.4"
+  resolved "https://registry.yarnpkg.com/@carbon/ibmdotcom-react/-/ibmdotcom-react-1.8.0-rc.4.tgz#e679235845b83abf4cf61b1ca4c722691c6c850e"
+  integrity sha512-ZlbFIdKQ2b5SKC6PuI11C4enD54WkiLEt2Sk4JrVkf8YV3EdQyxKstfogC8p+7d3iHBrGixGMg9yh5PCA+yIOg==
   dependencies:
     "@babel/runtime" "^7.5.5"
     "@carbon/ibmdotcom-services" "1.8.0-rc.2"
-    "@carbon/ibmdotcom-styles" "1.8.0-rc.2"
+    "@carbon/ibmdotcom-styles" "1.8.0-rc.3"
     "@carbon/ibmdotcom-utilities" "1.8.0-rc.2"
     autosuggest-highlight "^3.1.1"
     carbon-components "10.11.2"
@@ -1004,10 +1004,10 @@
     jsonp "^0.2.1"
     window-or-global "^1.0.1"
 
-"@carbon/ibmdotcom-styles@1.8.0-rc.2", "@carbon/ibmdotcom-styles@latest":
-  version "1.8.0-rc.2"
-  resolved "https://registry.yarnpkg.com/@carbon/ibmdotcom-styles/-/ibmdotcom-styles-1.8.0-rc.2.tgz#a1937e00cf71ce66b77e86ca95544a8c3e716169"
-  integrity sha512-vJRcjEKufQjzWC1jttZ++gBTWIJvGRhwkuq0cbrR8o6gZKmzSj7U7TYk9NrgwzftKQeG2NeBl+KsVcnryZ74iw==
+"@carbon/ibmdotcom-styles@1.8.0-rc.3", "@carbon/ibmdotcom-styles@^1.8.0-rc.3":
+  version "1.8.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@carbon/ibmdotcom-styles/-/ibmdotcom-styles-1.8.0-rc.3.tgz#f64b71ddf1fc157f0dba3f3776a596ba98c444a9"
+  integrity sha512-gmCk82pK1yQ42/44VCQl4L/piCdzY96S0Lyck24TvNKS61nLpKulvWRMIl+Z3ATdL3NuOuoukNJLNqObyOaH8g==
   dependencies:
     "@carbon/grid" "10.10.2"
     "@carbon/import-once" "10.3.0"


### PR DESCRIPTION
### Related Ticket(s)

no related issue

### Description

This commit changes the titles from lorem ipsum to the component names,
so there is a better understanding of what components are being used
by testers.

In addition, there were some deprecated imports for the Learn page which
was fixed, as well as some React console errors.

### Changelog

**Changed**

- Added `key` index for `altlang`
- Adjusted solution page titles to include the component names
- fixed deprecated style imports for the learn page
