### PR TITLE
feat(ServicesPage): added LeadSpace and ContentBlockSegmented

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -35,6 +35,13 @@ const Home = () => (
         },
       },
       {
+        heading: "Services",
+        copy: " ",
+        cta: {
+          href: `./services${_htmlExtension}`,
+        },
+      },
+      {
         heading: "More coming soon!",
         copy: " ",
         cta: {

--- a/pages/services.js
+++ b/pages/services.js
@@ -1,0 +1,99 @@
+/* eslint-disable sort-imports */
+/* eslint-disable jsx-a11y/anchor-is-valid, jsx-a11y/anchor-has-content */
+import "../styles/services.scss";
+
+import { ArrowRight20 } from "@carbon/icons-react";
+
+import {
+  LeadSpace,
+  TableOfContents,
+  ContentBlockSegmented,
+} from "@carbon/ibmdotcom-react";
+
+import React from "react";
+
+/**
+ * DDS patters template
+ *
+ * @returns {*} JSX for Services template
+ */
+const Services = () => (
+  <>
+    <LeadSpace
+      type="default"
+      theme="g100"
+      title="Leadspace title"
+      copy="Use this area for a short line of copy to support the title"
+      gradient={true}
+      buttons={[
+        {
+          copy: "Lorem ipsum dolor",
+          href: "https://www.ibm.com/services",
+          renderIcon: ArrowRight20,
+        },
+      ]}
+      image={{
+        defaultSrc: "https://dummyimage.com/1056x480/ee5396/161616",
+        alt: "Image alt text",
+        sources: [
+          {
+            src: "https://dummyimage.com/320x370/ee5396/161616",
+            breakpoint: "sm",
+          },
+          {
+            src: "https://dummyimage.com/672x400/ee5396/161616",
+            breakpoint: "md",
+          },
+        ],
+      }}
+    />
+    <TableOfContents theme="white" menuLabel="Jump to" stickyOffset={48}>
+      <a name="content-block-segmented" data-title="Content Block Segmented" />
+      <ContentBlockSegmented
+        heading="Content Block Segmented Title"
+        copy="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien."
+        cta={{
+          style: "card",
+          type: "local",
+          copy: "Services",
+          cta: {
+            href: "https;//www.ibm.com/services",
+          },
+        }}
+        items={[
+          {
+            heading: "Lorem ipsum doller",
+            copy: `
+            — Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. 
+
+            — Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. 
+
+
+            — Donec quis pretium odio, in dignissim sapien.`,
+          },
+          {
+            heading: "Lorem ipsum doller",
+            copy: `
+            — Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. 
+
+            — Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. 
+
+            
+            — Donec quis pretium odio, in dignissim sapien.`,
+          },
+          {
+            heading: "Lorem ipsum doller",
+            copy: `
+            — Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. 
+
+            — Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. 
+
+            
+            — Donec quis pretium odio, in dignissim sapien.`,
+          },
+        ]}
+      />
+    </TableOfContents>
+  </>
+);
+export default Services;

--- a/styles/services.scss
+++ b/styles/services.scss
@@ -1,4 +1,4 @@
 @import "~@carbon/ibmdotcom-styles/scss/patterns/sections/leadspace/leadspace";
-@import "@carbon/ibmdotcom-styles/scss/patterns/blocks/content-block-segmented/index";
+@import "~@carbon/ibmdotcom-styles/scss/patterns/blocks/content-block-segmented/index";
 
 @import "~@carbon/ibmdotcom-styles/scss/components/tableofcontents/index";

--- a/styles/services.scss
+++ b/styles/services.scss
@@ -1,0 +1,4 @@
+@import "~@carbon/ibmdotcom-styles/scss/patterns/sections/leadspace/leadspace";
+@import "@carbon/ibmdotcom-styles/scss/patterns/blocks/content-block-segmented/index";
+
+@import "~@carbon/ibmdotcom-styles/scss/components/tableofcontents/index";


### PR DESCRIPTION
### Related Ticket(s)

Build Services patterns page in NextJS [#2903](https://app.zenhub.com/workspaces/ibmcom-library-5d449f3642eb1962336cbe52/issues/carbon-design-system/ibm-dotcom-library/2903)

### Description

Added LeadSpace component and ContentBlockSegmented pattern to the Services Page

### Changelog

**New**

- LeadSpace
- ContentBlockSegmented 

