### PR TITLE
feat(ServicesPage): added ContentBlockMedia, LinkList and Layout

### DIFF
--- a/pages/services.js
+++ b/pages/services.js
@@ -11,6 +11,7 @@ import {
   Layout,
   ContentBlockMedia,
   LinkList,
+  CalloutWithMedia,
 } from "@carbon/ibmdotcom-react";
 
 import React from "react";
@@ -176,6 +177,15 @@ const Services = () => (
 
         <> </>
       </Layout>
+      <CalloutWithMedia
+        copy="Lorem ipsum dolor sit amet, consectetur adipiscing elit"
+        heading="Callout With Media heading"
+        mediaType="video"
+        mediaData={{
+          videoId: "0_uka1msg4",
+          showCaption: true,
+        }}
+      />
     </TableOfContents>
   </>
 );

--- a/pages/services.js
+++ b/pages/services.js
@@ -8,6 +8,9 @@ import {
   LeadSpace,
   TableOfContents,
   ContentBlockSegmented,
+  Layout,
+  ContentBlockMedia,
+  LinkList,
 } from "@carbon/ibmdotcom-react";
 
 import React from "react";
@@ -93,6 +96,86 @@ const Services = () => (
           },
         ]}
       />
+      <Layout nested={true} type="2-1" border={false}>
+        <div>
+          <a name="content-block-Mmedia" data-title="Content Block Media" />
+          <ContentBlockMedia
+            heading="Content Block Media Title"
+            items={[
+              {
+                mediaType: "video",
+                heading: "Content Title",
+                copy:
+                  "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam.",
+
+                mediaData: {
+                  videoId: "0_uka1msg4",
+                  showCaption: true,
+                },
+
+                items: [
+                  {
+                    copy:
+                      "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+                  },
+                ],
+              },
+              {
+                mediaType: "video",
+                heading: "Content Title",
+                copy:
+                  "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam.",
+
+                mediaData: {
+                  videoId: "0_uka1msg4",
+                  showCaption: true,
+                },
+
+                items: [
+                  {
+                    copy:
+                      "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+                  },
+                ],
+              },
+              {
+                mediaType: "video",
+                heading: "Content Title",
+                copy:
+                  "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam.",
+
+                mediaData: {
+                  videoId: "0_uka1msg4",
+                  showCaption: true,
+                },
+
+                items: [
+                  {
+                    copy:
+                      "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+                  },
+                ],
+              },
+            ]}
+          />
+          <LinkList
+            heading="LinkList heading"
+            style="vertical-end"
+            items={[
+              {
+                heading: "heading link",
+                type: "local",
+                copy: "Lorem ipsum",
+                cta: {
+                  href: "https://www.ibm.com/services",
+                },
+              },
+            ]}
+          />
+        </div>
+
+        <> </>
+      </Layout>
     </TableOfContents>
   </>
 );

--- a/pages/services.js
+++ b/pages/services.js
@@ -99,7 +99,7 @@ const Services = () => (
       />
       <Layout nested={true} type="2-1" border={false}>
         <div>
-          <a name="content-block-Mmedia" data-title="Content Block Media" />
+          <a name="content-block-media" data-title="Content Block Media" />
           <ContentBlockMedia
             heading="Content Block Media Title"
             items={[

--- a/pages/services.js
+++ b/pages/services.js
@@ -8,12 +8,10 @@ import {
   LeadSpace,
   TableOfContents,
   ContentBlockSegmented,
-
   Layout,
   ContentBlockMedia,
   LinkList,
   CalloutWithMedia,
-
   ContentBlockCards,
   CardLink,
 
@@ -190,6 +188,8 @@ const Services = () => (
         mediaData={{
           videoId: "0_uka1msg4",
           showCaption: true,
+        }}
+      />
 
       <a
         name="content-block-cards-and-card-link"
@@ -245,9 +245,8 @@ const Services = () => (
             href: "https;//www.ibm.com/services",
             icon: {
               src: ArrowRight20,
-            },
-          },
-
+            }
+          }
         }}
       />
     </TableOfContents>

--- a/styles/services.scss
+++ b/styles/services.scss
@@ -1,4 +1,7 @@
 @import "~@carbon/ibmdotcom-styles/scss/patterns/sections/leadspace/leadspace";
 @import "~@carbon/ibmdotcom-styles/scss/patterns/blocks/content-block-segmented/index";
+@import "~@carbon/ibmdotcom-styles/scss/patterns/blocks/content-block-media/index";
 
 @import "~@carbon/ibmdotcom-styles/scss/components/tableofcontents/index";
+@import "~@carbon/ibmdotcom-styles/scss/components/link-list/index";
+@import "~@carbon/ibmdotcom-styles/scss/components/layout/layout";

--- a/styles/services.scss
+++ b/styles/services.scss
@@ -1,6 +1,7 @@
 @import "~@carbon/ibmdotcom-styles/scss/patterns/sections/leadspace/leadspace";
 @import "~@carbon/ibmdotcom-styles/scss/patterns/blocks/content-block-segmented/index";
 @import "~@carbon/ibmdotcom-styles/scss/patterns/blocks/content-block-media/index";
+@import "@carbon/ibmdotcom-styles/scss/patterns/blocks/callout-with-media/index";
 
 @import "~@carbon/ibmdotcom-styles/scss/components/tableofcontents/index";
 @import "~@carbon/ibmdotcom-styles/scss/components/link-list/index";


### PR DESCRIPTION
### Related Ticket(s)

Build Services patterns page in NextJS [#2903](https://app.zenhub.com/workspaces/ibmcom-library-5d449f3642eb1962336cbe52/issues/carbon-design-system/ibm-dotcom-library/2903)

### Description

One another section added to Services page, which contains ContentBlockMedia pattern and LinkList, Layout component.


**Note: CSS is unstable, there is a moment that loads and there is a moment that doesn't.**
LinkList component isn't rendering properly, because of this CSS instability

### Changelog

**New**

- Content Block Media
- LinkList
- Layout

