### PR TITLE
feat(ServicesPage): added ContentBlockCards and CardLink

### DIFF
--- a/pages/services.js
+++ b/pages/services.js
@@ -8,6 +8,8 @@ import {
   LeadSpace,
   TableOfContents,
   ContentBlockSegmented,
+  ContentBlockCards,
+  CardLink,
 } from "@carbon/ibmdotcom-react";
 
 import React from "react";
@@ -92,6 +94,64 @@ const Services = () => (
             — Donec quis pretium odio, in dignissim sapien.`,
           },
         ]}
+      />
+      <a
+        name="content-block-cards-and-card-Link"
+        data-title="Content Block Cards and Card Link"
+      />
+      <ContentBlockCards
+        heading="Content Block Cards and Card Link"
+        cards={[
+          {
+            image: {
+              defaultSrc:
+                "https://dummyimage.com/1056x792/ee5396/161616%26text=4:3",
+              alt: "Image alt text",
+            },
+            eyebrow: "Lorem",
+            heading: "Lorem ipsum dolor sit amet, consectetur adip possib",
+            cta: {
+              href: "https://www.example.com",
+            },
+          },
+          {
+            image: {
+              defaultSrc:
+                "https://dummyimage.com/792x1056/ee5396/161616%26text=3:4",
+              alt: "Image alt text",
+            },
+            eyebrow: "Lorem",
+            heading: "Lorem ipsum dolor sit amet, consectetur adip possib",
+            cta: {
+              href: "https://www.example.com",
+            },
+          },
+          {
+            image: {
+              defaultSrc:
+                "https://dummyimage.com/1056x1056/ee5396/161616%26text=1:1",
+              alt: "Image alt text",
+            },
+            eyebrow: "Lorem",
+            heading: "Lorem ipsum dolor sit amet, consectetur adip possib",
+            cta: {
+              href: "https://www.example.com",
+            },
+          },
+        ]}
+      />
+
+      <CardLink
+        card={{
+          copy: "Services",
+          cta: {
+            type: "local",
+            href: "https;//www.ibm.com/services",
+            icon: {
+              src: ArrowRight20,
+            },
+          },
+        }}
       />
     </TableOfContents>
   </>

--- a/pages/services.js
+++ b/pages/services.js
@@ -96,7 +96,7 @@ const Services = () => (
         ]}
       />
       <a
-        name="content-block-cards-and-card-Link"
+        name="content-block-cards-and-card-link"
         data-title="Content Block Cards and Card Link"
       />
       <ContentBlockCards

--- a/styles/services.scss
+++ b/styles/services.scss
@@ -1,6 +1,6 @@
 @import "~@carbon/ibmdotcom-styles/scss/patterns/sections/leadspace/leadspace";
 @import "~@carbon/ibmdotcom-styles/scss/patterns/blocks/content-block-segmented/index";
-@import "~@carbon/ibmdotcom-styles/scss/patterns/blocks/content-block-cards/content-block-cards.scss";
+@import "~@carbon/ibmdotcom-styles/scss/patterns/blocks/content-block-cards/content-block-cards";
 
 @import "~@carbon/ibmdotcom-styles/scss/components/tableofcontents/index";
 @import "~@carbon/ibmdotcom-styles/scss/components/card-link/card-link";

--- a/styles/services.scss
+++ b/styles/services.scss
@@ -2,3 +2,4 @@
 @import "~@carbon/ibmdotcom-styles/scss/patterns/blocks/content-block-segmented/index";
 
 @import "~@carbon/ibmdotcom-styles/scss/components/tableofcontents/index";
+@import "~@carbon/ibmdotcom-styles/scss/components/card-link/card-link";

--- a/styles/services.scss
+++ b/styles/services.scss
@@ -1,5 +1,6 @@
 @import "~@carbon/ibmdotcom-styles/scss/patterns/sections/leadspace/leadspace";
 @import "~@carbon/ibmdotcom-styles/scss/patterns/blocks/content-block-segmented/index";
+@import "~@carbon/ibmdotcom-styles/scss/patterns/blocks/content-block-cards/content-block-cards.scss";
 
 @import "~@carbon/ibmdotcom-styles/scss/components/tableofcontents/index";
 @import "~@carbon/ibmdotcom-styles/scss/components/card-link/card-link";


### PR DESCRIPTION
### Related Ticket(s)

Build Services patterns page in NextJS [#2903](https://app.zenhub.com/workspaces/ibmcom-library-5d449f3642eb1962336cbe52/issues/carbon-design-system/ibm-dotcom-library/2903)

### Description

Added the third section to the Services page using the ContentBlockCards and CardLink

**Note: CSS is unstable, there is a moment that loads and there is a moment that doesn't.**
Cards on the ContentBlockCards pattern isn't rendering properly, because of this CSS instability


### Changelog

**New**

- ContentBlockCards
- CardLink
