### PR TITLE
chore(common): moved ibm-common to dynamic injection on page load

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -41,6 +41,7 @@ module.exports = withSass(
       ROOT_PATH: process.env.ROOT_PATH || "/",
       KALTURA_PARTNER_ID: process.env.KALTURA_PARTNER_ID || "1773841",
       KALTURA_UICONF_ID: process.env.KALTURA_UICONF_ID || "27941801",
+      DDS_CALLOUT_DATA: process.env.DDS_CALLOUT_DATA || "false",
     },
     sassLoaderOptions: {
       includePaths: [path.resolve(__dirname, "node_modules")],

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "start": "node server.js",
     "build-export": "next build && next export",
     "lint": "eslint pages && eslint components",
-    "lint:styles": "stylelint '**/*.{css,scss}' --config ./packages/stylelint-config-ibmdotcom --fix",
+    "lint:styles": "stylelint '**/*.{css,scss}' --config ./packages/stylelint-config-ibmdotcom",
     "update": "yarn upgrade @carbon/ibmdotcom-react@canary && yarn upgrade @carbon/ibmdotcom-styles@canary && yarn upgrade @carbon/ibmdotcom-services@canary && yarn upgrade @carbon/ibmdotcom-utilities@canary",
     "update-staging": "yarn upgrade @carbon/ibmdotcom-react@latest && yarn upgrade @carbon/ibmdotcom-styles@latest"
   },

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -74,6 +74,10 @@ export default class IbmdotcomLibrary extends App {
             }}
           />
           <Altlang />
+          <script
+            src="//1.www.s81c.com/common/stats/ibm-common.js"
+            defer
+          ></script>
         </Head>
         <DotcomShell
           mastheadProps={{
@@ -86,9 +90,16 @@ export default class IbmdotcomLibrary extends App {
           <Component {...pageProps} />
         </DotcomShell>
         <script
-          src="//1.www.s81c.com/common/stats/ibm-common.js"
-          defer
-        ></script>
+          dangerouslySetInnerHTML={{
+            __html: `
+            window.addEventListener("load", function() {
+             var loadScript = document.createElement('script');
+             loadScript.src = 'https://cdn.optimizely.com/js/PROJECT_ID.js';
+             document.head.appendChild(loadScript);
+            });
+           `,
+          }}
+        />
       </>
     );
   }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -85,7 +85,10 @@ export default class IbmdotcomLibrary extends App {
         >
           <Component {...pageProps} />
         </DotcomShell>
-        <script src="//1.www.s81c.com/common/stats/ibm-common.js"></script>
+        <script
+          src="//1.www.s81c.com/common/stats/ibm-common.js"
+          defer
+        ></script>
       </>
     );
   }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -74,10 +74,6 @@ export default class IbmdotcomLibrary extends App {
             }}
           />
           <Altlang />
-          <script
-            src="//1.www.s81c.com/common/stats/ibm-common.js"
-            defer
-          ></script>
         </Head>
         <DotcomShell
           mastheadProps={{
@@ -89,6 +85,24 @@ export default class IbmdotcomLibrary extends App {
         >
           <Component {...pageProps} />
         </DotcomShell>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+            function initIBMCommon() {
+              var element = document.createElement("script");
+              element.src = "//1.www.s81c.com/common/stats/ibm-common.js";
+              document.body.appendChild(element);
+            }
+            if (window.addEventListener) {
+              window.addEventListener("load", initIBMCommon, false);
+            } else if (window.attachEvent) {
+              window.attachEvent("onload", initIBMCommon);
+            } else {
+              window.onload = initIBMCommon;
+            }
+           `,
+          }}
+        />
       </>
     );
   }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -89,17 +89,6 @@ export default class IbmdotcomLibrary extends App {
         >
           <Component {...pageProps} />
         </DotcomShell>
-        <script
-          dangerouslySetInnerHTML={{
-            __html: `
-            window.addEventListener("load", function() {
-             var loadScript = document.createElement('script');
-             loadScript.src = 'https://cdn.optimizely.com/js/PROJECT_ID.js';
-             document.head.appendChild(loadScript);
-            });
-           `,
-          }}
-        />
       </>
     );
   }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -88,18 +88,11 @@ export default class IbmdotcomLibrary extends App {
         <script
           dangerouslySetInnerHTML={{
             __html: `
-            function initIBMCommon() {
+            window.addEventListener("load", function() {
               var element = document.createElement("script");
               element.src = "//1.www.s81c.com/common/stats/ibm-common.js";
               document.body.appendChild(element);
-            }
-            if (window.addEventListener) {
-              window.addEventListener("load", initIBMCommon, false);
-            } else if (window.attachEvent) {
-              window.attachEvent("onload", initIBMCommon);
-            } else {
-              window.onload = initIBMCommon;
-            }
+            });            
            `,
           }}
         />

--- a/pages/services.js
+++ b/pages/services.js
@@ -4,6 +4,7 @@ import "../styles/services.scss";
 
 import { ArrowRight20 } from "@carbon/icons-react";
 
+import { AccordionItem, Accordion } from "carbon-components-react";
 import {
   LeadSpace,
   TableOfContents,
@@ -154,6 +155,11 @@ const Services = () => (
         }}
       />
     </TableOfContents>
+    <Accordion>
+      <AccordionItem title="Footnotes">
+        <p> Lorem ipsum dolor sit amet, consectetur adipiscing elit</p>
+      </AccordionItem>
+    </Accordion>
   </>
 );
 export default Services;


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/ibm-dotcom-library/issues/3067

### Description

This changes the way that `ibm-common.js` to be dynamically injected after the page has been loaded. Before, changing it to `defer` seems to improve performance, but for some reason scripts are still blocking. 

### Changelog

**Changed**

- Moved `ibm-common.js` from defer to dynamic injection
- Fixed duplicate import issue for `services.scss`
- Put scss and react imports into alphabetical order